### PR TITLE
Fixed spelling error in README.rdoc: creat -> create

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -52,10 +52,10 @@ Starting off with a simple user model.
 A fixture for the user model can be defined using the @fixture@ method.
 
   User.fixture {{
-    :username             => (username = /\w+/.gen),
-    :email                => "#{username}@example.com",
-    :password             => (password = /\w+/.gen),
-    :pasword_confirmation => password
+    :username              => (username = /\w+/.gen),
+    :email                 => "#{username}@example.com",
+    :password              => (password = /\w+/.gen),
+    :password_confirmation => password
 
     # The /\w+/.gen notation is part of the randexp gem:
     # http://github.com/benburkert/randexp/

--- a/README.rdoc
+++ b/README.rdoc
@@ -94,7 +94,7 @@ Now to a model that has given attributes, use
 
   Person.gen(:valid)
 
-@generate@ (or @gen@) method uses @create@ method of DataMapper models. This means that validations are run on the model. There are two other methods you can use to creat data - @make@ to build a model that has not been saved, and @generate!@ to force saving of the model even if it is invalid (it uses @create!@ internally).
+@generate@ (or @gen@) method uses @create@ method of DataMapper models. This means that validations are run on the model. There are two other methods you can use to create data - @make@ to build a model that has not been saved, and @generate!@ to force saving of the model even if it is invalid (it uses @create!@ internally).
 
   Person.make(:valid)
   Person.generate!(:invalid) # You can also use #gen!


### PR DESCRIPTION
Reading through the README I noticed a simple spelling error. I have correct it.
