### PR TITLE
ParseTree is gone for Ruby 1.9, silence warning

### DIFF
--- a/lib/dm-sweatshop/unique.rb
+++ b/lib/dm-sweatshop/unique.rb
@@ -62,7 +62,7 @@ module DataMapper
         gem 'ParseTree', '~>3.0.3'
         require 'parse_tree'
       rescue LoadError
-        puts "DataMapper::Sweatshop::Unique - ParseTree could not be loaded, anonymous uniques will not be allowed"
+        # ParseTree could not be loaded, anonymous uniques will not be allowed
       end unless defined?(JRUBY_VERSION)
 
       ClassAttributes.accessor(self, :count_map)

--- a/lib/dm-sweatshop/unique.rb
+++ b/lib/dm-sweatshop/unique.rb
@@ -62,7 +62,7 @@ module DataMapper
         gem 'ParseTree', '~>3.0.3'
         require 'parse_tree'
       rescue LoadError
-        # ParseTree could not be loaded, anonymous uniques will not be allowed
+        puts "DataMapper::Sweatshop::Unique - ParseTree could not be loaded, anonymous uniques will not be allowed" unless RUBY_VERSION.to_f >= 1.9
       end unless defined?(JRUBY_VERSION)
 
       ClassAttributes.accessor(self, :count_map)


### PR DESCRIPTION
Silence ParseTree warning, as it won't be available for Ruby 1.9. Still informs via self.key_for

It's still an great piece of software used by many, it's just missing a minor feature.
