### PR TITLE
Use rubygems only if they exist

### DIFF
--- a/lib/dm-sweatshop/unique.rb
+++ b/lib/dm-sweatshop/unique.rb
@@ -60,7 +60,9 @@ module DataMapper
 
       unless defined?(JRUBY_VERSION) || RUBY_VERSION >= '1.9'
         begin
-          gem 'ParseTree', '~>3.0.3'
+          if respond_to?(:gem, true)
+            gem 'ParseTree', '~>3.0.3'
+          end
           require 'parse_tree'
         rescue LoadError
           puts 'DataMapper::Sweatshop::Unique - ParseTree could not be loaded, anonymous uniques will not be allowed'


### PR DESCRIPTION
I'm trying to test integrity which uses dm-sweatshop, and receive the following error:

<pre>
/usr/local/lib/ruby/vendor_ruby/1.8/dm-core.rb:26: warning: already initialized constant Mash
/usr/local/lib/ruby/vendor_ruby/1.8/dm-sweatshop/unique.rb:66: undefined method `gem' for DataMapper::Sweatshop::UniqueWorker:Class (NoMethodError)
    from /usr/local/lib/ruby/vendor_ruby/1.8/dm-sweatshop.rb:6:in `require'
    from /usr/local/lib/ruby/vendor_ruby/1.8/dm-sweatshop.rb:6
    from ./test/helper.rb:4:in `require'
    from ./test/helper.rb:4
    from ./test/unit/build_test.rb:1:in `require'
    from ./test/unit/build_test.rb:1
    from /usr/local/lib/ruby/vendor_ruby/1.8/rake/rake_test_loader.rb:5:in `load'
    from /usr/local/lib/ruby/vendor_ruby/1.8/rake/rake_test_loader.rb:5
    from /usr/local/lib/ruby/vendor_ruby/1.8/rake/rake_test_loader.rb:5:in `each'
    from /usr/local/lib/ruby/vendor_ruby/1.8/rake/rake_test_loader.rb:5
rake aborted!
</pre>


gem should only be called if it exists.
