### PR TITLE
Allow Model#generate_attributes to get a hash of attributes

### DIFF
--- a/lib/dm-sweatshop/model.rb
+++ b/lib/dm-sweatshop/model.rb
@@ -58,14 +58,16 @@ module DataMapper
 
     # Returns a Hash of attributes from the model map.
     #
-    # @param     name     [Symbol]   name of the fauxture to use
+    # @param     name        [Symbol]   name of the fauxture to use
+    # @param     attributes  [Hash]
     #
     # @return   [Hash]              existing instance of a model from the model map
     # @raise    NoFixtureExist      when requested fixture does not exist in the model map
     #
     # @api       public
-    def generate_attributes(name = default_fauxture_name)
-      Sweatshop.attributes(self, name)
+    def generate_attributes(name = default_fauxture_name, attributes = {})
+      name, attributes = default_fauxture_name, name if name.is_a? Hash
+      Sweatshop.attributes(self, name, attributes)
     end
 
     alias_method :gen_attrs, :generate_attributes

--- a/lib/dm-sweatshop/sweatshop.rb
+++ b/lib/dm-sweatshop/sweatshop.rb
@@ -58,7 +58,7 @@ module DataMapper
     #
     # @return   [DataMapper::Resource]    added instance
     def self.create!(klass, name, overrides = {})
-      record(klass, name, klass.create!(attributes(klass, name, overrides).merge(overrides)))
+      record(klass, name, klass.create!(attributes(klass, name, overrides)))
     end
 
     # Creates an instance from given hash of attributes, saves it
@@ -72,7 +72,7 @@ module DataMapper
     #
     # @return   [DataMapper::Resource]    added instance
     def self.create(klass, name, overrides = {})
-      record(klass, name, klass.create(attributes(klass, name, overrides).merge(overrides)))
+      record(klass, name, klass.create(attributes(klass, name, overrides)))
     end
 
     # Creates an instance from given hash of attributes
@@ -86,7 +86,7 @@ module DataMapper
     #
     # @return   [DataMapper::Resource]    added instance
     def self.make(klass, name, overrides = {})
-      record(klass, name, klass.new(attributes(klass, name, overrides).merge(overrides)))
+      record(klass, name, klass.new(attributes(klass, name, overrides)))
     end
 
     # Returns a pre existing instance of a model from the record map
@@ -115,7 +115,7 @@ module DataMapper
       proc = model_map[klass][name.to_sym].pick
 
       if proc
-        expand_callable_values(proc.call(overrides))
+        expand_callable_values(proc.call(overrides)).merge(overrides)
       elsif klass.superclass.is_a?(DataMapper::Model)
         attributes(klass.superclass, name, overrides)
       else

--- a/lib/dm-sweatshop/sweatshop.rb
+++ b/lib/dm-sweatshop/sweatshop.rb
@@ -58,7 +58,7 @@ module DataMapper
     #
     # @return   [DataMapper::Resource]    added instance
     def self.create!(klass, name, overrides = {})
-      record(klass, name, klass.create!(attributes(klass, name).merge(overrides)))
+      record(klass, name, klass.create!(attributes(klass, name, overrides).merge(overrides)))
     end
 
     # Creates an instance from given hash of attributes, saves it
@@ -72,7 +72,7 @@ module DataMapper
     #
     # @return   [DataMapper::Resource]    added instance
     def self.create(klass, name, overrides = {})
-      record(klass, name, klass.create(attributes(klass, name).merge(overrides)))
+      record(klass, name, klass.create(attributes(klass, name, overrides).merge(overrides)))
     end
 
     # Creates an instance from given hash of attributes
@@ -86,7 +86,7 @@ module DataMapper
     #
     # @return   [DataMapper::Resource]    added instance
     def self.make(klass, name, overrides = {})
-      record(klass, name, klass.new(attributes(klass, name).merge(overrides)))
+      record(klass, name, klass.new(attributes(klass, name, overrides).merge(overrides)))
     end
 
     # Returns a pre existing instance of a model from the record map
@@ -111,13 +111,13 @@ module DataMapper
     # @raise    NoFixtureExist  when requested fixture does not exist in the model map
     #
     # @api       private
-    def self.attributes(klass, name)
+    def self.attributes(klass, name, overrides={})
       proc = model_map[klass][name.to_sym].pick
 
       if proc
-        expand_callable_values(proc.call)
+        expand_callable_values(proc.call(overrides))
       elsif klass.superclass.is_a?(DataMapper::Model)
-        attributes(klass.superclass, name)
+        attributes(klass.superclass, name, overrides)
       else
         raise NoFixtureExist, "#{name} fixture was not found for class #{klass}"
       end

--- a/lib/dm-sweatshop/sweatshop.rb
+++ b/lib/dm-sweatshop/sweatshop.rb
@@ -52,13 +52,13 @@ module DataMapper
     #
     # @param     klass       [Class, DataMapper::Resource]
     # @param     name        [Symbol]
-    # @param     attributes  [Hash]
+    # @param     overrides   [Hash]
     #
     # @api       private
     #
     # @return   [DataMapper::Resource]    added instance
-    def self.create!(klass, name, attributes = {})
-      record(klass, name, klass.create!(attributes(klass, name).merge(attributes)))
+    def self.create!(klass, name, overrides = {})
+      record(klass, name, klass.create!(attributes(klass, name).merge(overrides)))
     end
 
     # Creates an instance from given hash of attributes, saves it
@@ -66,13 +66,13 @@ module DataMapper
     #
     # @param     klass       [Class, DataMapper::Resource]
     # @param     name        [Symbol]
-    # @param     attributes  [Hash]
+    # @param     overrides   [Hash]
     #
     # @api       private
     #
     # @return   [DataMapper::Resource]    added instance
-    def self.create(klass, name, attributes = {})
-      record(klass, name, klass.create(attributes(klass, name).merge(attributes)))
+    def self.create(klass, name, overrides = {})
+      record(klass, name, klass.create(attributes(klass, name).merge(overrides)))
     end
 
     # Creates an instance from given hash of attributes
@@ -80,13 +80,13 @@ module DataMapper
     #
     # @param     klass       [Class, DataMapper::Resource]
     # @param     name        [Symbol]
-    # @param     attributes  [Hash]
+    # @param     overrides   [Hash]
     #
     # @api       private
     #
     # @return   [DataMapper::Resource]    added instance
-    def self.make(klass, name, attributes = {})
-      record(klass, name, klass.new(attributes(klass, name).merge(attributes)))
+    def self.make(klass, name, overrides = {})
+      record(klass, name, klass.new(attributes(klass, name).merge(overrides)))
     end
 
     # Returns a pre existing instance of a model from the record map

--- a/spec/dm-sweatshop/model_spec.rb
+++ b/spec/dm-sweatshop/model_spec.rb
@@ -201,21 +201,37 @@ describe DataMapper::Model do
 
     describe ".generate_attributes" do
       before :each do
+        Widget.fix {{
+          :name  => "normal",
+          :price => 10
+        }}
         Widget.fix(:red) {{
           :name  => "red",
           :price => 20
         }}
-
-        @hash = Widget.generate_attributes(:red)
       end
 
       it "returns a Hash" do
+        @hash = Widget.generate_attributes(:red)
         @hash.should be_an_instance_of(Hash)
       end
 
       it "returns stored attributes hash by name" do
+        @hash = Widget.generate_attributes(:red)
         @hash[:name].should == "red"
         @hash[:price].should == 20
+      end
+
+      it "allows attributes to be overridden" do
+        @hash = Widget.generate_attributes(:name => 'peter')
+        @hash[:name].should == "peter"
+        @hash[:price].should == 10
+      end
+
+      it "allows attributes to be overridden for custom factories" do
+        @hash = Widget.generate_attributes(:red, :price => 30)
+        @hash[:name].should == "red"
+        @hash[:price].should == 30
       end
     end
 

--- a/spec/dm-sweatshop/model_spec.rb
+++ b/spec/dm-sweatshop/model_spec.rb
@@ -56,6 +56,21 @@ describe DataMapper::Model do
         end
       end
 
+      describe "with block argument" do
+        before :each do
+          Widget.fixture do |attrs|
+            {
+              :name => attrs.delete(:title)
+            }
+          end
+        end
+
+        it "passes the attributes to the block" do
+          widget = Widget.gen(:title => 'Hello')
+          widget.name.should == 'Hello'
+        end
+      end
+
       it "should allow handle complex named fixtures" do
         Wonket.fix {{
           :name => /\w+ Wonket/.gen.capitalize,


### PR DESCRIPTION
For consistency with Model#generate and Model#make, Model#generate_attributes should allow to take a hash of attributes.
